### PR TITLE
Add Missing Scim2-Client and Okio Dependencies 

### DIFF
--- a/components/org.wso2.carbon.identity.provisioning.connector.scim2/pom.xml
+++ b/components/org.wso2.carbon.identity.provisioning.connector.scim2/pom.xml
@@ -115,6 +115,10 @@
 			<version>${powermock.version}</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.squareup.okio</groupId>
+			<artifactId>okio</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -171,6 +175,7 @@
 							org.apache.commons.logging; version="${commons-logging.osgi.version.range}",
 							org.apache.commons.collections; version="${commons-collections.wso2.osgi.version.range}",
 							org.apache.commons.lang; version="${commons-lang.wso2.osgi.version.range}",
+							org.json;version="${json.wso2.version.range}",
 							org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
 							org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",
 							org.wso2.carbon.identity.application.common.model;
@@ -185,7 +190,11 @@
 							!org.wso2.carbon.identity.provisioning.connector.scim2.internal,
 							org.wso2.carbon.identity.provisioning.connector.scim2.*;
 							version="${identity.outbound.provisioning.scim2.export.version}"
+							com.squareup.okio.*
 						</Export-Package>
+						<Embed-Dependency>
+							org.wso2.carbon.extension.identity.scim2.client;okio;scope=compile|runtime;inline=false
+						</Embed-Dependency>
 					</instructions>
 				</configuration>
 			</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,11 @@
                 <artifactId>commons-lang</artifactId>
                 <version>${commons-lang.wso2.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.squareup.okio</groupId>
+                <artifactId>okio</artifactId>
+                <version>${okio.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -237,7 +242,7 @@
         <commons-logging.osgi.version.range>[1.2,2.0)</commons-logging.osgi.version.range>
         <commons-collections.wso2.osgi.version.range>[3.2.0,4.0.0)</commons-collections.wso2.osgi.version.range>
         <commons-lang.wso2.version>2.6.0.wso2v1</commons-lang.wso2.version>
-        <identity.scim2.client.version>[1.0.0,2.0.0)</identity.scim2.client.version>
+        <identity.scim2.client.version>1.0.2</identity.scim2.client.version>
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <maven.scr.plugin.version>1.7.2</maven.scr.plugin.version>
         <maven.bundle.plugin.version>2.4.0</maven.bundle.plugin.version>
@@ -248,6 +253,8 @@
         <maven.surefire.plugin.version>2.18.1</maven.surefire.plugin.version>
         <mockito.version>1.10.19</mockito.version>
         <powermock.version>1.6.5</powermock.version>
+        <okio.version>1.9.0</okio.version>
+        <json.wso2.version.range>[3.0.0.wso2v1, 4.0.0)</json.wso2.version.range>
     </properties>
 
 </project>


### PR DESCRIPTION
This PR adds the missing identity-client-scim2 and okio dependencies that are needed to facilitate outbound provisioning with SCIM2 in product-IS.

NOTE: identity-client-scim2 version should be updated after merging https://github.com/wso2-extensions/identity-client-scim2/pull/19

Resolves: https://github.com/wso2/product-is/issues/14202