### PR TITLE
Bump Maven Bundle Plugin Version

### DIFF
--- a/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/main/java/org/wso2/carbon/identity/provisioning/connector/scim2/internal/SCIM2ConnectorServiceComponent.java
+++ b/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/main/java/org/wso2/carbon/identity/provisioning/connector/scim2/internal/SCIM2ConnectorServiceComponent.java
@@ -20,7 +20,7 @@ package org.wso2.carbon.identity.provisioning.connector.scim2.internal;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.osgi.framework.BundleContext;
+import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.wso2.carbon.identity.provisioning.AbstractProvisioningConnectorFactory;
@@ -37,7 +37,7 @@ public class SCIM2ConnectorServiceComponent {
     private static final Log log = LogFactory.getLog(SCIM2ConnectorServiceComponent.class);
 
     @Activate
-    protected void activate(BundleContext context) {
+    protected void activate(ComponentContext context) {
 
         if (log.isDebugEnabled()) {
             log.debug("Activating SCIM2ConnectorServiceComponent");
@@ -46,7 +46,7 @@ public class SCIM2ConnectorServiceComponent {
         try {
             SCIM2ProvisioningConnectorFactory scim2ProvisioningConnectorFactory = new
                     SCIM2ProvisioningConnectorFactory();
-            context.registerService(AbstractProvisioningConnectorFactory.class.getName(),
+            context.getBundleContext().registerService(AbstractProvisioningConnectorFactory.class.getName(),
                     scim2ProvisioningConnectorFactory, null);
             if (log.isDebugEnabled()) {
                 log.debug("SCIM2 Provisioning Connector bundle is activated");

--- a/pom.xml
+++ b/pom.xml
@@ -264,7 +264,7 @@
         <identity.scim2.client.version>1.0.2</identity.scim2.client.version>
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <maven.scr.plugin.version>1.7.2</maven.scr.plugin.version>
-        <maven.bundle.plugin.version>2.4.0</maven.bundle.plugin.version>
+        <maven.bundle.plugin.version>3.2.0</maven.bundle.plugin.version>
         <maven.compiler.plugin.version>2.3.1</maven.compiler.plugin.version>
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
         <testng.version>6.9.10</testng.version>


### PR DESCRIPTION
This PR bumps the maven-bundle-plugin version from 2.4.0 to 3.2.0 to resolve OSGI bundle registering issues and reverts changes added to the method signature of `activate(ComponentContext context)` from https://github.com/wso2-extensions/identity-outbound-provisioning-scim2/pull/15.

Related Issue: https://github.com/wso2/product-is/issues/14203