### PR TITLE
Change SCIM2 Variable Names

### DIFF
--- a/components/org.wso2.carbon.identity.provisioning.connector.scim2/pom.xml
+++ b/components/org.wso2.carbon.identity.provisioning.connector.scim2/pom.xml
@@ -20,7 +20,7 @@
 		<groupId>org.wso2.carbon.identity.outbound.provisioning.scim2</groupId>
 		<artifactId>identity-outbound-provisioning-scim2</artifactId>
 		<relativePath>../../pom.xml</relativePath>
-		<version>1.0.7-SNAPSHOT</version>
+		<version>2.0.0-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/main/java/org/wso2/carbon/identity/provisioning/connector/scim2/SCIM2ProvisioningConnector.java
+++ b/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/main/java/org/wso2/carbon/identity/provisioning/connector/scim2/SCIM2ProvisioningConnector.java
@@ -74,23 +74,23 @@ public class SCIM2ProvisioningConnector extends AbstractOutboundProvisioningConn
         scimProvider = new SCIMProvider();
         if (provisioningProperties != null && provisioningProperties.length > 0) {
             for (Property property : provisioningProperties) {
-                if (SCIM2ProvisioningConnectorConstants.SCIM_USER_EP.equals(property.getName())) {
+                if (SCIM2ProvisioningConnectorConstants.SCIM2_USER_EP.equals(property.getName())) {
                     populateSCIMProvider(property, SCIM2CommonConstants.ELEMENT_NAME_USER_ENDPOINT);
-                } else if (SCIM2ProvisioningConnectorConstants.SCIM_GROUP_EP.equals(property.getName())) {
+                } else if (SCIM2ProvisioningConnectorConstants.SCIM2_GROUP_EP.equals(property.getName())) {
                     populateSCIMProvider(property, SCIM2CommonConstants.ELEMENT_NAME_GROUP_ENDPOINT);
-                } else if (SCIM2ProvisioningConnectorConstants.SCIM_USERNAME.equals(property.getName())) {
+                } else if (SCIM2ProvisioningConnectorConstants.SCIM2_USERNAME.equals(property.getName())) {
                     populateSCIMProvider(property, SCIMConstants.UserSchemaConstants.USER_NAME);
-                } else if (SCIM2ProvisioningConnectorConstants.SCIM_PASSWORD.equals(property.getName())) {
+                } else if (SCIM2ProvisioningConnectorConstants.SCIM2_PASSWORD.equals(property.getName())) {
                     populateSCIMProvider(property, SCIMConstants.UserSchemaConstants.PASSWORD);
-                } else if (SCIM2ProvisioningConnectorConstants.SCIM_USERSTORE_DOMAIN.equals(property.getName())) {
+                } else if (SCIM2ProvisioningConnectorConstants.SCIM2_USERSTORE_DOMAIN.equals(property.getName())) {
                     userStoreDomainName = property.getValue() != null ? property.getValue()
                             : property.getDefaultValue();
-                } else if (SCIM2ProvisioningConnectorConstants.SCIM_ENABLE_PASSWORD_PROVISIONING.equals(property.
+                } else if (SCIM2ProvisioningConnectorConstants.SCIM2_ENABLE_PASSWORD_PROVISIONING.equals(property.
                         getName())) {
                     populateSCIMProvider(property, SCIM2ProvisioningConnectorConstants.
-                            SCIM_ENABLE_PASSWORD_PROVISIONING);
-                } else if (SCIM2ProvisioningConnectorConstants.SCIM_DEFAULT_PASSWORD.equals(property.getName())) {
-                    populateSCIMProvider(property, SCIM2ProvisioningConnectorConstants.SCIM_DEFAULT_PASSWORD);
+                            SCIM2_ENABLE_PASSWORD_PROVISIONING);
+                } else if (SCIM2ProvisioningConnectorConstants.SCIM2_DEFAULT_PASSWORD.equals(property.getName())) {
+                    populateSCIMProvider(property, SCIM2ProvisioningConnectorConstants.SCIM2_DEFAULT_PASSWORD);
                 }
 
                 if (IdentityProvisioningConstants.JIT_PROVISIONING_ENABLED.equals(property
@@ -359,7 +359,7 @@ public class SCIM2ProvisioningConnector extends AbstractOutboundProvisioningConn
      */
     @Override
     public String getClaimDialectUri() throws IdentityProvisioningException {
-        return SCIM2ProvisioningConnectorConstants.DEFAULT_SCIM_DIALECT;
+        return SCIM2ProvisioningConnectorConstants.DEFAULT_SCIM2_DIALECT;
     }
 
     /**
@@ -373,11 +373,11 @@ public class SCIM2ProvisioningConnector extends AbstractOutboundProvisioningConn
     private void setUserPassword(User user, ProvisioningEntity userEntity) throws CharonException, BadRequestException {
 
         if ("true".equals(scimProvider.getProperty(SCIM2ProvisioningConnectorConstants.
-                SCIM_ENABLE_PASSWORD_PROVISIONING))) {
+                SCIM2_ENABLE_PASSWORD_PROVISIONING))) {
             setPassword(user, getPassword(userEntity.getAttributes()));
         } else if (StringUtils.isNotBlank(scimProvider.getProperty(SCIM2ProvisioningConnectorConstants.
-                SCIM_DEFAULT_PASSWORD))) {
-            setPassword(user, scimProvider.getProperty(SCIM2ProvisioningConnectorConstants.SCIM_DEFAULT_PASSWORD));
+                SCIM2_DEFAULT_PASSWORD))) {
+            setPassword(user, scimProvider.getProperty(SCIM2ProvisioningConnectorConstants.SCIM2_DEFAULT_PASSWORD));
         }
     }
 

--- a/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/main/java/org/wso2/carbon/identity/provisioning/connector/scim2/SCIM2ProvisioningConnectorConstants.java
+++ b/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/main/java/org/wso2/carbon/identity/provisioning/connector/scim2/SCIM2ProvisioningConnectorConstants.java
@@ -24,15 +24,15 @@ public class SCIM2ProvisioningConnectorConstants {
     private SCIM2ProvisioningConnectorConstants() {
     }
 
-    public static final String SCIM_USER_EP = "scim-user-ep";
-    public static final String SCIM_GROUP_EP = "scim-group-ep";
-    public static final String SCIM_USERNAME = "scim-username";
-    public static final String SCIM_PASSWORD = "scim-password";
-    public static final String SCIM_USERSTORE_DOMAIN = "scim-user-store-domain";
-    public static final String DEFAULT_SCIM_DIALECT = "urn:scim:schemas:core:2.0";
+    public static final String SCIM2_USER_EP = "scim2-user-ep";
+    public static final String SCIM2_GROUP_EP = "scim2-group-ep";
+    public static final String SCIM2_USERNAME = "scim2-username";
+    public static final String SCIM2_PASSWORD = "scim2-password";
+    public static final String SCIM2_USERSTORE_DOMAIN = "scim2-user-store-domain";
+    public static final String DEFAULT_SCIM2_DIALECT = "urn:scim:schemas:core:2.0";
 
-    public static final String SCIM_ENABLE_PASSWORD_PROVISIONING = "scim-enable-pwd-provisioning";
-    public static final String SCIM_DEFAULT_PASSWORD = "scim-default-pwd";
+    public static final String SCIM2_ENABLE_PASSWORD_PROVISIONING = "scim2-enable-pwd-provisioning";
+    public static final String SCIM2_DEFAULT_PASSWORD = "scim2-default-pwd";
 
     public static final String DEFAULT = "default";
     public static final String ATTRIBUTE_TYPE = ".type";

--- a/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/main/java/org/wso2/carbon/identity/provisioning/connector/scim2/SCIM2ProvisioningConnectorFactory.java
+++ b/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/main/java/org/wso2/carbon/identity/provisioning/connector/scim2/SCIM2ProvisioningConnectorFactory.java
@@ -75,42 +75,42 @@ public class SCIM2ProvisioningConnectorFactory extends AbstractProvisioningConne
         List<Property> properties = new ArrayList<Property>();
 
         Property username = new Property();
-        username.setName(SCIM2ProvisioningConnectorConstants.SCIM_USERNAME);
+        username.setName(SCIM2ProvisioningConnectorConstants.SCIM2_USERNAME);
         username.setDisplayName("Username");
         username.setDisplayOrder(1);
         username.setRequired(true);
 
         Property userPassword = new Property();
-        userPassword.setName(SCIM2ProvisioningConnectorConstants.SCIM_PASSWORD);
+        userPassword.setName(SCIM2ProvisioningConnectorConstants.SCIM2_PASSWORD);
         userPassword.setDisplayName("Password");
         userPassword.setConfidential(true);
         userPassword.setDisplayOrder(2);
         userPassword.setRequired(true);
 
         Property userEndpoint = new Property();
-        userEndpoint.setName(SCIM2ProvisioningConnectorConstants.SCIM_USER_EP);
+        userEndpoint.setName(SCIM2ProvisioningConnectorConstants.SCIM2_USER_EP);
         userEndpoint.setDisplayName("User Endpoint");
         userEndpoint.setDisplayOrder(3);
         userEndpoint.setRequired(true);
 
         Property groupEndpoint = new Property();
-        groupEndpoint.setName(SCIM2ProvisioningConnectorConstants.SCIM_GROUP_EP);
+        groupEndpoint.setName(SCIM2ProvisioningConnectorConstants.SCIM2_GROUP_EP);
         groupEndpoint.setDisplayName("Group Endpoint");
         groupEndpoint.setDisplayOrder(4);
 
         Property userStoreDomain = new Property();
-        userStoreDomain.setName(SCIM2ProvisioningConnectorConstants.SCIM_USERSTORE_DOMAIN);
+        userStoreDomain.setName(SCIM2ProvisioningConnectorConstants.SCIM2_USERSTORE_DOMAIN);
         userStoreDomain.setDisplayName("User Store Domain");
         userStoreDomain.setDisplayOrder(5);
 
         Property passwordProvisioning = new Property();
-        passwordProvisioning.setName(SCIM2ProvisioningConnectorConstants.SCIM_ENABLE_PASSWORD_PROVISIONING);
+        passwordProvisioning.setName(SCIM2ProvisioningConnectorConstants.SCIM2_ENABLE_PASSWORD_PROVISIONING);
         passwordProvisioning.setDisplayName("Enable Password Provisioning");
         passwordProvisioning.setDescription("Enable User password provisioning to a SCIM2 domain");
         passwordProvisioning.setDisplayOrder(6);
 
         Property defaultPassword = new Property();
-        defaultPassword.setName(SCIM2ProvisioningConnectorConstants.SCIM_DEFAULT_PASSWORD);
+        defaultPassword.setName(SCIM2ProvisioningConnectorConstants.SCIM2_DEFAULT_PASSWORD);
         defaultPassword.setDisplayName("Default Password");
         defaultPassword.setDisplayOrder(7);
 

--- a/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/test/java/org.wso2.carbon.identity.provisioning.connector.scim2.test/SCIM2ProvisioningConnectorTest.java
+++ b/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/test/java/org.wso2.carbon.identity.provisioning.connector.scim2.test/SCIM2ProvisioningConnectorTest.java
@@ -82,7 +82,7 @@ public class SCIM2ProvisioningConnectorTest extends PowerMockTestCase {
     public void testCreateUser() throws Exception {
 
         PowerMockito.when(scimProvider.getProperty(SCIM2ProvisioningConnectorConstants.
-                SCIM_ENABLE_PASSWORD_PROVISIONING)).thenReturn("true");
+                SCIM2_ENABLE_PASSWORD_PROVISIONING)).thenReturn("true");
         sCIM2ProvisioningConnector.init(new Property[0]);
         PowerMockito.whenNew(ProvisioningClient.class).withArguments(Mockito.anyObject(), Mockito.anyObject(),
                 Mockito.anyObject()).thenReturn(provisioningClient);
@@ -105,7 +105,7 @@ public class SCIM2ProvisioningConnectorTest extends PowerMockTestCase {
     public void testUpdateUser() throws Exception {
 
         PowerMockito.when(scimProvider.getProperty(SCIM2ProvisioningConnectorConstants.
-                SCIM_ENABLE_PASSWORD_PROVISIONING)).thenReturn("true");
+                SCIM2_ENABLE_PASSWORD_PROVISIONING)).thenReturn("true");
         sCIM2ProvisioningConnector.init(new Property[0]);
         PowerMockito.whenNew(ProvisioningClient.class).withArguments(Mockito.anyObject(), Mockito.anyObject(),
                 Mockito.anyObject()).thenReturn(provisioningClient);
@@ -128,7 +128,7 @@ public class SCIM2ProvisioningConnectorTest extends PowerMockTestCase {
     public void testDeleteUser() throws Exception {
 
         PowerMockito.when(scimProvider.getProperty(SCIM2ProvisioningConnectorConstants.
-                SCIM_ENABLE_PASSWORD_PROVISIONING)).thenReturn("true");
+                SCIM2_ENABLE_PASSWORD_PROVISIONING)).thenReturn("true");
         sCIM2ProvisioningConnector.init(new Property[0]);
         PowerMockito.whenNew(ProvisioningClient.class).withArguments(Mockito.anyObject(), Mockito.anyObject(),
                 Mockito.anyObject()).thenReturn(provisioningClient);
@@ -205,10 +205,10 @@ public class SCIM2ProvisioningConnectorTest extends PowerMockTestCase {
 
         sCIM2ProvisioningConnector.init(new Property[0]);
         Property property = new Property();
-        property.setName(SCIM2ProvisioningConnectorConstants.SCIM_USERNAME);
+        property.setName(SCIM2ProvisioningConnectorConstants.SCIM2_USERNAME);
         property.setValue("testUser");
         Whitebox.invokeMethod(sCIM2ProvisioningConnector, "populateSCIMProvider",property,
-                SCIM2ProvisioningConnectorConstants.SCIM_USERNAME);
+                SCIM2ProvisioningConnectorConstants.SCIM2_USERNAME);
     }
 
     @Test

--- a/features/org.wso2.carbon.identity.provisioning.connector.scim2.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.provisioning.connector.scim2.server.feature/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.outbound.provisioning.scim2</groupId>
         <artifactId>identity-outbound-provisioning-scim2</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.0.7-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -255,7 +255,7 @@
         <osgi.service.component.imp.pkg.version.range>[1.2.0, 2.0.0)</osgi.service.component.imp.pkg.version.range>
         <!-- Charon version -->
         <charon.wso2.version.identity>3.1.21</charon.wso2.version.identity>
-        <charon.wso2.import.version.range>[3.0.0, 4.0.0)</charon.wso2.import.version.range>
+        <charon.wso2.import.version.range>[3.0.0, 4.1.0)</charon.wso2.import.version.range>
         <!-- Commons -->
         <commons-lang.wso2.osgi.version.range>[2.6.0,3.0.0)</commons-lang.wso2.osgi.version.range>
         <commons-logging.osgi.version.range>[1.2,2.0)</commons-logging.osgi.version.range>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <groupId>org.wso2.carbon.identity.outbound.provisioning.scim2</groupId>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>identity-outbound-provisioning-scim2</artifactId>
-    <version>1.0.7-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>WSO2 Carbon - SCIM 2.0 - Provisioning Module</name>
     <description>

--- a/pom.xml
+++ b/pom.xml
@@ -244,7 +244,7 @@
         <carbon.identity.framework.import.version.range>[5.0.0, 6.0.0)</carbon.identity.framework.import.version.range>
         <identity.framework.version>5.5.0</identity.framework.version>
         <carbon.identity.framework.import.version.range>[5.0.0, 6.0.0)</carbon.identity.framework.import.version.range>
-        <identity.inbound.provisioning.scim.version>1.1.19</identity.inbound.provisioning.scim.version>
+        <identity.inbound.provisioning.scim.version>5.1.3</identity.inbound.provisioning.scim.version>
         <identity.inbound.provisioning.scim.import.version.range>[5.0.0, 6.0.0)
         </identity.inbound.provisioning.scim.import.version.range>
         <identity.outbound.provisioning.scim2.export.version>${project.version}


### PR DESCRIPTION
This PR changes the SCIM2 outbound connector variable names from scim to scim2.

Related Issue: https://github.com/wso2/product-is/issues/14266