### PR TITLE
Fix Claim Resolving Issues during User Update

### DIFF
--- a/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/main/java/org/wso2/carbon/identity/provisioning/connector/scim2/SCIM2ProvisioningConnector.java
+++ b/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/main/java/org/wso2/carbon/identity/provisioning/connector/scim2/SCIM2ProvisioningConnector.java
@@ -243,22 +243,6 @@ public class SCIM2ProvisioningConnector extends AbstractOutboundProvisioningConn
     }
 
     /**
-     * Gets the domain free username.
-     *
-     * @param nameWithDomain
-     * @return
-     */
-    private String extractDomainFreeName(String nameWithDomain) {
-        int domainSeparatorIdx = nameWithDomain.indexOf(UserCoreConstants.DOMAIN_SEPARATOR);
-        if (domainSeparatorIdx > 0) {
-            String[] names = nameWithDomain.split(UserCoreConstants.DOMAIN_SEPARATOR);
-            return names[1].trim();
-        } else {
-            return null;
-        }
-    }
-
-    /**
      * Creates the group.
      *
      * @param groupEntity
@@ -368,14 +352,17 @@ public class SCIM2ProvisioningConnector extends AbstractOutboundProvisioningConn
     }
 
     /**
-     * Returns the Claim dialect Uri.
+     * Returns the Claim dialect URIs.
      *
-     * @return Scim dialect
+     * @return Scim dialects
      * @throws IdentityProvisioningException Error when getting the claim dialect URI.
      */
     @Override
-    public String getClaimDialectUri() throws IdentityProvisioningException {
-        return SCIM2ProvisioningConnectorConstants.DEFAULT_SCIM2_DIALECT;
+    public String[] getClaimDialectUris() {
+
+        return new String[]{SCIM2ProvisioningConnectorConstants.DEFAULT_SCIM2_CORE_DIALECT,
+                SCIM2ProvisioningConnectorConstants.DEFAULT_SCIM2_USER_DIALECT,
+                SCIM2ProvisioningConnectorConstants.DEFAULT_SCIM2_ENTERPRISE_DIALECT};
     }
 
     /**
@@ -488,5 +475,22 @@ public class SCIM2ProvisioningConnector extends AbstractOutboundProvisioningConn
     @Override
     protected String getUserStoreDomainName() {
         return userStoreDomainName;
+    }
+
+    /**
+     * Gets the domain free username.
+     *
+     * @param nameWithDomain Username with domain.
+     * @return domainFreeName
+     */
+    private String extractDomainFreeName(String nameWithDomain) {
+
+        int domainSeparatorIdx = nameWithDomain.indexOf(UserCoreConstants.DOMAIN_SEPARATOR);
+        if (domainSeparatorIdx > 0) {
+            String[] names = nameWithDomain.split(UserCoreConstants.DOMAIN_SEPARATOR);
+            return names[1].trim();
+        } else {
+            return null;
+        }
     }
 }

--- a/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/main/java/org/wso2/carbon/identity/provisioning/connector/scim2/SCIM2ProvisioningConnector.java
+++ b/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/main/java/org/wso2/carbon/identity/provisioning/connector/scim2/SCIM2ProvisioningConnector.java
@@ -31,6 +31,7 @@ import org.wso2.carbon.identity.provisioning.ProvisioningEntityType;
 import org.wso2.carbon.identity.provisioning.ProvisioningOperation;
 import org.wso2.carbon.identity.provisioning.ProvisioningUtil;
 import org.wso2.carbon.identity.provisioning.connector.scim2.util.SCIMClaimResolver;
+import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.charon3.core.attributes.ComplexAttribute;
 import org.wso2.charon3.core.attributes.DefaultAttributeFactory;
@@ -220,7 +221,7 @@ public class SCIM2ProvisioningConnector extends AbstractOutboundProvisioningConn
         try {
             List<String> userNames = getUserNames(userEntity.getAttributes());
             if (CollectionUtils.isNotEmpty(userNames)) {
-                userName = userNames.get(0);
+                userName = extractDomainFreeName(userNames.get(0));
             }
             User user;
             // get single-valued claims
@@ -232,13 +233,28 @@ public class SCIM2ProvisioningConnector extends AbstractOutboundProvisioningConn
                 user = new User();
             }
             user.setUserName(userName);
-            setUserPassword(user, userEntity);
             ProvisioningClient scimProvisioningClient = new ProvisioningClient(scimProvider, user, null);
             if (ProvisioningOperation.PUT.equals(provisioningOperation)) {
                 scimProvisioningClient.provisionUpdateUser();
             }
         } catch (Exception e) {
             throw new IdentityProvisioningException("Error while updating the user : " + userName, e);
+        }
+    }
+
+    /**
+     * Gets the domain free username.
+     *
+     * @param nameWithDomain
+     * @return
+     */
+    private String extractDomainFreeName(String nameWithDomain) {
+        int domainSeparatorIdx = nameWithDomain.indexOf(UserCoreConstants.DOMAIN_SEPARATOR);
+        if (domainSeparatorIdx > 0) {
+            String[] names = nameWithDomain.split(UserCoreConstants.DOMAIN_SEPARATOR);
+            return names[1].trim();
+        } else {
+            return null;
         }
     }
 

--- a/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/main/java/org/wso2/carbon/identity/provisioning/connector/scim2/SCIM2ProvisioningConnector.java
+++ b/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/main/java/org/wso2/carbon/identity/provisioning/connector/scim2/SCIM2ProvisioningConnector.java
@@ -355,7 +355,6 @@ public class SCIM2ProvisioningConnector extends AbstractOutboundProvisioningConn
      * Returns the Claim dialect URIs.
      *
      * @return Scim dialects
-     * @throws IdentityProvisioningException Error when getting the claim dialect URI.
      */
     @Override
     public String[] getClaimDialectUris() {
@@ -490,7 +489,11 @@ public class SCIM2ProvisioningConnector extends AbstractOutboundProvisioningConn
             String[] names = nameWithDomain.split(UserCoreConstants.DOMAIN_SEPARATOR);
             return names[1].trim();
         } else {
-            return null;
+            if (log.isDebugEnabled()) {
+                log.debug(String.format("Domain is not available for username: %s. Therefore returning the " +
+                        "original username.", nameWithDomain));
+            }
+            return nameWithDomain;
         }
     }
 }

--- a/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/main/java/org/wso2/carbon/identity/provisioning/connector/scim2/SCIM2ProvisioningConnectorConstants.java
+++ b/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/main/java/org/wso2/carbon/identity/provisioning/connector/scim2/SCIM2ProvisioningConnectorConstants.java
@@ -29,7 +29,9 @@ public class SCIM2ProvisioningConnectorConstants {
     public static final String SCIM2_USERNAME = "scim2-username";
     public static final String SCIM2_PASSWORD = "scim2-password";
     public static final String SCIM2_USERSTORE_DOMAIN = "scim2-user-store-domain";
-    public static final String DEFAULT_SCIM2_DIALECT = "urn:ietf:params:scim:schemas:core:2.0:User";
+    public static final String DEFAULT_SCIM2_CORE_DIALECT = "urn:ietf:params:scim:schemas:core:2.0";
+    public static final String DEFAULT_SCIM2_USER_DIALECT = "urn:ietf:params:scim:schemas:core:2.0:User";
+    public static final String DEFAULT_SCIM2_ENTERPRISE_DIALECT = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User";
 
     public static final String SCIM2_ENABLE_PASSWORD_PROVISIONING = "scim2-enable-pwd-provisioning";
     public static final String SCIM2_DEFAULT_PASSWORD = "scim2-default-pwd";

--- a/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/main/java/org/wso2/carbon/identity/provisioning/connector/scim2/SCIM2ProvisioningConnectorConstants.java
+++ b/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/main/java/org/wso2/carbon/identity/provisioning/connector/scim2/SCIM2ProvisioningConnectorConstants.java
@@ -29,7 +29,7 @@ public class SCIM2ProvisioningConnectorConstants {
     public static final String SCIM2_USERNAME = "scim2-username";
     public static final String SCIM2_PASSWORD = "scim2-password";
     public static final String SCIM2_USERSTORE_DOMAIN = "scim2-user-store-domain";
-    public static final String DEFAULT_SCIM2_DIALECT = "urn:scim:schemas:core:2.0";
+    public static final String DEFAULT_SCIM2_DIALECT = "urn:ietf:params:scim:schemas:core:2.0:User";
 
     public static final String SCIM2_ENABLE_PASSWORD_PROVISIONING = "scim2-enable-pwd-provisioning";
     public static final String SCIM2_DEFAULT_PASSWORD = "scim2-default-pwd";

--- a/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/main/java/org/wso2/carbon/identity/provisioning/connector/scim2/SCIM2ProvisioningConnectorFactory.java
+++ b/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/main/java/org/wso2/carbon/identity/provisioning/connector/scim2/SCIM2ProvisioningConnectorFactory.java
@@ -19,6 +19,7 @@ package org.wso2.carbon.identity.provisioning.connector.scim2;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.application.common.model.Property;
+import org.wso2.carbon.identity.application.common.model.SubProperty;
 import org.wso2.carbon.identity.provisioning.AbstractOutboundProvisioningConnector;
 import org.wso2.carbon.identity.provisioning.AbstractProvisioningConnectorFactory;
 import org.wso2.carbon.identity.provisioning.IdentityProvisioningException;
@@ -79,6 +80,7 @@ public class SCIM2ProvisioningConnectorFactory extends AbstractProvisioningConne
         username.setDisplayName("Username");
         username.setDisplayOrder(1);
         username.setRequired(true);
+        username.setType("string");
 
         Property userPassword = new Property();
         userPassword.setName(SCIM2ProvisioningConnectorConstants.SCIM2_PASSWORD);
@@ -86,33 +88,46 @@ public class SCIM2ProvisioningConnectorFactory extends AbstractProvisioningConne
         userPassword.setConfidential(true);
         userPassword.setDisplayOrder(2);
         userPassword.setRequired(true);
+        userPassword.setType("string");
 
         Property userEndpoint = new Property();
         userEndpoint.setName(SCIM2ProvisioningConnectorConstants.SCIM2_USER_EP);
         userEndpoint.setDisplayName("User Endpoint");
         userEndpoint.setDisplayOrder(3);
         userEndpoint.setRequired(true);
+        userEndpoint.setType("string");
 
         Property groupEndpoint = new Property();
         groupEndpoint.setName(SCIM2ProvisioningConnectorConstants.SCIM2_GROUP_EP);
         groupEndpoint.setDisplayName("Group Endpoint");
         groupEndpoint.setDisplayOrder(4);
+        groupEndpoint.setType("string");
+        groupEndpoint.setRequired(false);
 
         Property userStoreDomain = new Property();
         userStoreDomain.setName(SCIM2ProvisioningConnectorConstants.SCIM2_USERSTORE_DOMAIN);
         userStoreDomain.setDisplayName("User Store Domain");
         userStoreDomain.setDisplayOrder(5);
+        userStoreDomain.setRequired(false);
+        userStoreDomain.setType("string");
 
         Property passwordProvisioning = new Property();
         passwordProvisioning.setName(SCIM2ProvisioningConnectorConstants.SCIM2_ENABLE_PASSWORD_PROVISIONING);
         passwordProvisioning.setDisplayName("Enable Password Provisioning");
         passwordProvisioning.setDescription("Enable User password provisioning to a SCIM2 domain");
         passwordProvisioning.setDisplayOrder(6);
+        passwordProvisioning.setRequired(false);
+        passwordProvisioning.setType("boolean");
+        passwordProvisioning.setDefaultValue("true");
 
-        Property defaultPassword = new Property();
+        SubProperty defaultPassword = new SubProperty();
         defaultPassword.setName(SCIM2ProvisioningConnectorConstants.SCIM2_DEFAULT_PASSWORD);
         defaultPassword.setDisplayName("Default Password");
         defaultPassword.setDisplayOrder(7);
+        defaultPassword.setRequired(false);
+        defaultPassword.setType("string");
+        defaultPassword.setConfidential(true);
+        passwordProvisioning.setSubProperties(new SubProperty[] {defaultPassword});
 
         properties.add(username);
         properties.add(userPassword);
@@ -120,7 +135,6 @@ public class SCIM2ProvisioningConnectorFactory extends AbstractProvisioningConne
         properties.add(groupEndpoint);
         properties.add(userStoreDomain);
         properties.add(passwordProvisioning);
-        properties.add(defaultPassword);
 
         return properties;
     }

--- a/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/test/java/org.wso2.carbon.identity.provisioning.connector.scim2.test/SCIM2ProvisioningConnectorFactoryTest.java
+++ b/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/test/java/org.wso2.carbon.identity.provisioning.connector.scim2.test/SCIM2ProvisioningConnectorFactoryTest.java
@@ -20,6 +20,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.application.common.model.Property;
+import org.wso2.carbon.identity.application.common.model.SubProperty;
 import org.wso2.carbon.identity.provisioning.connector.scim2.SCIM2ProvisioningConnectorFactory;
 
 import java.util.ArrayList;
@@ -65,9 +66,9 @@ public class SCIM2ProvisioningConnectorFactoryTest {
         Property userStoreDomain = new Property();
         configProperties.add(userStoreDomain);
         Property passwordProvisioning = new Property();
+        SubProperty defaultPassword = new SubProperty();
+        passwordProvisioning.setSubProperties(new SubProperty[] {defaultPassword});
         configProperties.add(passwordProvisioning);
-        Property defaultPassword = new Property();
-        configProperties.add(defaultPassword);
         Assert.assertEquals(configProperties.size(), scim2ProvisioningConnectorFactory.getConfigurationProperties().
                 size());
     }

--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,7 @@
     <properties>
         <!--Carbon framework version-->
         <carbon.identity.framework.import.version.range>[5.0.0, 6.0.0)</carbon.identity.framework.import.version.range>
-        <identity.framework.version>5.5.0</identity.framework.version>
+        <identity.framework.version>5.21.35</identity.framework.version>
         <carbon.identity.framework.import.version.range>[5.0.0, 6.0.0)</carbon.identity.framework.import.version.range>
         <identity.inbound.provisioning.scim.version>5.1.3</identity.inbound.provisioning.scim.version>
         <identity.inbound.provisioning.scim.import.version.range>[5.0.0, 6.0.0)

--- a/pom.xml
+++ b/pom.xml
@@ -254,14 +254,14 @@
         <osgi.framework.imp.pkg.version.range>[1.7.0, 2.0.0)</osgi.framework.imp.pkg.version.range>
         <osgi.service.component.imp.pkg.version.range>[1.2.0, 2.0.0)</osgi.service.component.imp.pkg.version.range>
         <!-- Charon version -->
-        <charon.wso2.version.identity>3.1.21</charon.wso2.version.identity>
+        <charon.wso2.version.identity>4.0.1</charon.wso2.version.identity>
         <charon.wso2.import.version.range>[3.0.0, 4.1.0)</charon.wso2.import.version.range>
         <!-- Commons -->
         <commons-lang.wso2.osgi.version.range>[2.6.0,3.0.0)</commons-lang.wso2.osgi.version.range>
         <commons-logging.osgi.version.range>[1.2,2.0)</commons-logging.osgi.version.range>
         <commons-collections.wso2.osgi.version.range>[3.2.0,4.0.0)</commons-collections.wso2.osgi.version.range>
         <commons-lang.wso2.version>2.6.0.wso2v1</commons-lang.wso2.version>
-        <identity.scim2.client.version>1.0.2</identity.scim2.client.version>
+        <identity.scim2.client.version>1.0.3</identity.scim2.client.version>
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <maven.scr.plugin.version>1.7.2</maven.scr.plugin.version>
         <maven.bundle.plugin.version>3.2.0</maven.bundle.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,7 @@
     <properties>
         <!--Carbon framework version-->
         <carbon.identity.framework.import.version.range>[5.0.0, 6.0.0)</carbon.identity.framework.import.version.range>
-        <identity.framework.version>5.21.35</identity.framework.version>
+        <identity.framework.version>5.21.37</identity.framework.version>
         <carbon.identity.framework.import.version.range>[5.0.0, 6.0.0)</carbon.identity.framework.import.version.range>
         <identity.inbound.provisioning.scim.version>5.1.3</identity.inbound.provisioning.scim.version>
         <identity.inbound.provisioning.scim.import.version.range>[5.0.0, 6.0.0)


### PR DESCRIPTION
This PR resolves the following issues related to resolving claims during user updating.

1. The claim dialect `urn:scim:schemas:core:2.0` is an invalid dialect and is changed to `urn:ietf:params:scim:schemas:core:2.0:User`.

2. In the scim2 PUT request to update an existing user, if the username added through the body contains the userstore domain the following error response is obtained.
```
{
    "schemas": [
        "urn:ietf:params:scim:api:messages:2.0:Error"
    ],
    "scimType": "mutability",
    "detail": "Attribute userName cannot be modified.",
    "status": "400"
}
```
Therefore the domain is removed from the username and the domain free name is included in the patching request body.

3. The user's password is not passed as an attribute in the userEntity during the updateUser method of the scim2 outbound connector. But by trying to set the password at https://github.com/wso2-extensions/identity-outbound-provisioning-scim2/pull/18/files#diff-f6635fac98f39272a692a2d2f45996db89d1e273e8345c6a481b5d422d32804bL235, a random UUID is set to the user entity and will be added to the PUT request body during scim2 update request which gives the following error response.
```
{
    "schemas": [
        "urn:ietf:params:scim:api:messages:2.0:Error"
    ],
    "scimType": "invalidValue",
    "detail": "36001 - Un-expected error during pre update credential by admin, Password length should be within 5 to 30 characters",
    "status": "400"
}
```

Related Issue: https://github.com/wso2/product-is/issues/14378