### PR TITLE
Update Dependencies to IPK versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,11 +241,11 @@
 
     <properties>
         <!--Carbon framework version-->
-        <carbon.identity.framework.import.version.range>[5.0.0, 6.0.0)</carbon.identity.framework.import.version.range>
-        <identity.framework.version>5.21.37</identity.framework.version>
-        <carbon.identity.framework.import.version.range>[5.0.0, 6.0.0)</carbon.identity.framework.import.version.range>
-        <identity.inbound.provisioning.scim.version>5.1.3</identity.inbound.provisioning.scim.version>
-        <identity.inbound.provisioning.scim.import.version.range>[5.0.0, 6.0.0)
+        <carbon.identity.framework.import.version.range>[6.0.0, 7.0.0)</carbon.identity.framework.import.version.range>
+        <identity.framework.version>6.0.0</identity.framework.version>
+        <carbon.identity.framework.import.version.range>[6.0.0, 7.0.0)</carbon.identity.framework.import.version.range>
+        <identity.inbound.provisioning.scim.version>6.0.0</identity.inbound.provisioning.scim.version>
+        <identity.inbound.provisioning.scim.import.version.range>[6.0.0, 7.0.0)
         </identity.inbound.provisioning.scim.import.version.range>
         <identity.outbound.provisioning.scim2.export.version>${project.version}
         </identity.outbound.provisioning.scim2.export.version>


### PR DESCRIPTION
The identity components are bumped to major versions created for IPK.

Related issue: https://github.com/wso2-enterprise/identity-k8s-access-runtime/issues/16