### PR TITLE
Update okio & scim2-client dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -260,7 +260,7 @@
         <commons-logging.osgi.version.range>[1.2,2.0)</commons-logging.osgi.version.range>
         <commons-collections.wso2.osgi.version.range>[3.2.0,4.0.0)</commons-collections.wso2.osgi.version.range>
         <commons-lang.wso2.version>2.6.0.wso2v1</commons-lang.wso2.version>
-        <identity.scim2.client.version>2.0.0</identity.scim2.client.version>
+        <identity.scim2.client.version>2.0.1</identity.scim2.client.version>
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <maven.scr.plugin.version>1.7.2</maven.scr.plugin.version>
         <maven.bundle.plugin.version>3.2.0</maven.bundle.plugin.version>
@@ -271,7 +271,7 @@
         <maven.surefire.plugin.version>2.18.1</maven.surefire.plugin.version>
         <mockito.version>1.10.19</mockito.version>
         <powermock.version>1.6.5</powermock.version>
-        <okio.version>1.9.0</okio.version>
+        <okio.version>3.6.0</okio.version>
         <json.wso2.version.range>[3.0.0.wso2v1, 4.0.0)</json.wso2.version.range>
         <apache.felix.scr.ds.annotations.version>1.2.10</apache.felix.scr.ds.annotations.version>
     </properties>


### PR DESCRIPTION
## Purpose
- Bump `Okio` version to 3.6.0
- Bump scim2-client version to 2.0.1

NOTE: identity-client-scim2 version should be updated after merging https://github.com/wso2-extensions/identity-client-scim2/pull/23


## Related Issue
- https://github.com/wso2/product-is/issues/17755