### PR TITLE
Implement client credential for outbound provisioning

### DIFF
--- a/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/main/java/org/wso2/carbon/identity/provisioning/connector/scim2/SCIM2OAuth2TokenManager.java
+++ b/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/main/java/org/wso2/carbon/identity/provisioning/connector/scim2/SCIM2OAuth2TokenManager.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.provisioning.connector.scim2;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.json.JSONObject;
+import org.wso2.scim2.auth.TokenManager;
+
+import org.wso2.scim2.util.SCIM2ClientConfig;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+/**
+ * OAuth 2.0 Client Credentials token manager for SCIM2 outbound provisioning.
+ */
+public class SCIM2OAuth2TokenManager implements TokenManager {
+
+    private static final Log log = LogFactory.getLog(SCIM2OAuth2TokenManager.class);
+    private static final String GRANT_TYPE_CLIENT_CREDENTIALS = "grant_type=client_credentials";
+    private static final int MAX_RESPONSE_SIZE = 65536;
+
+    private final String tokenEndpoint;
+    private final String clientId;
+    private final String clientSecret;
+    private final String scope;
+    private final Object tokenLock = new Object();
+
+    private volatile String accessToken;
+
+    public SCIM2OAuth2TokenManager(String tokenEndpoint, String clientId, String clientSecret, String scope) {
+
+        if (StringUtils.isBlank(tokenEndpoint)) {
+            throw new IllegalArgumentException("Token endpoint URL must not be empty");
+        }
+        if (!tokenEndpoint.toLowerCase().startsWith("https://")) {
+            throw new IllegalArgumentException(
+                    "Token endpoint must use HTTPS. Provided: " + tokenEndpoint);
+        }
+        if (StringUtils.isBlank(clientId)) {
+            throw new IllegalArgumentException("Client ID must not be empty");
+        }
+        if (StringUtils.isBlank(clientSecret)) {
+            throw new IllegalArgumentException("Client secret must not be empty");
+        }
+
+        this.tokenEndpoint = tokenEndpoint;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.scope = scope;
+    }
+
+    @Override
+    public String getAccessToken() throws Exception {
+
+        String token = accessToken;
+        if (token != null) {
+            return token;
+        }
+        synchronized (tokenLock) {
+            if (accessToken != null) {
+                return accessToken;
+            }
+            accessToken = acquireToken();
+            return accessToken;
+        }
+    }
+
+    @Override
+    public String refreshToken(String expiredToken) throws Exception {
+
+        synchronized (tokenLock) {
+            accessToken = null;
+            accessToken = acquireToken();
+            if (log.isDebugEnabled()) {
+                log.debug("Successfully refreshed OAuth2 access token from: " + tokenEndpoint);
+            }
+            return accessToken;
+        }
+    }
+
+    private String acquireToken() throws IOException {
+
+        HttpURLConnection connection = null;
+        try {
+            URL url = new URL(tokenEndpoint);
+            connection = (HttpURLConnection) url.openConnection();
+            connection.setRequestMethod("POST");
+            connection.setDoOutput(true);
+            SCIM2ClientConfig clientConfig = SCIM2ClientConfig.getInstance();
+            connection.setConnectTimeout(clientConfig.getHttpConnectionTimeoutInMillis());
+            connection.setReadTimeout(clientConfig.getHttpReadTimeoutInMillis());
+            connection.setInstanceFollowRedirects(false);
+            connection.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+
+            // Basic Auth header: Base64(clientId:clientSecret).
+            String credentials = clientId + ":" + clientSecret;
+            String encodedCredentials = Base64.getEncoder().encodeToString(
+                    credentials.getBytes(StandardCharsets.UTF_8));
+            connection.setRequestProperty("Authorization", "Basic " + encodedCredentials);
+
+            // Build request body.
+            String requestBody = GRANT_TYPE_CLIENT_CREDENTIALS;
+            if (StringUtils.isNotBlank(scope)) {
+                requestBody += "&scope=" + URLEncoder.encode(scope, StandardCharsets.UTF_8.name());
+            }
+
+            try (OutputStream os = connection.getOutputStream()) {
+                os.write(requestBody.getBytes(StandardCharsets.UTF_8));
+            }
+
+            int responseCode = connection.getResponseCode();
+            if (responseCode != HttpURLConnection.HTTP_OK) {
+                String errorResponse = readResponse(connection, true);
+                // Sanitize error response to prevent log injection via control characters.
+                String sanitizedError = errorResponse.replaceAll("[\\r\\n\\t]", " ");
+                throw new IOException("Token endpoint returned HTTP " + responseCode +
+                        ". Response: " + sanitizedError);
+            }
+
+            String responseBody = readResponse(connection, false);
+            JSONObject jsonResponse = new JSONObject(responseBody);
+
+            if (!jsonResponse.has("access_token")) {
+                throw new IOException("Token endpoint response does not contain 'access_token' field");
+            }
+
+            String token = jsonResponse.getString("access_token");
+            if (log.isDebugEnabled()) {
+                log.debug("Successfully acquired OAuth2 access token from: " + tokenEndpoint);
+            }
+            return token;
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
+        }
+    }
+
+    private String readResponse(HttpURLConnection connection, boolean errorStream) throws IOException {
+
+        StringBuilder response = new StringBuilder();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(
+                errorStream ? connection.getErrorStream() : connection.getInputStream(),
+                StandardCharsets.UTF_8))) {
+            String line;
+            int totalRead = 0;
+            while ((line = reader.readLine()) != null) {
+                totalRead += line.length();
+                if (totalRead > MAX_RESPONSE_SIZE) {
+                    throw new IOException("Token endpoint response exceeded maximum size of " + MAX_RESPONSE_SIZE +
+                            " characters");
+                }
+                response.append(line);
+            }
+        }
+        return response.toString();
+    }
+}

--- a/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/main/java/org/wso2/carbon/identity/provisioning/connector/scim2/SCIM2ProvisioningConnector.java
+++ b/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/main/java/org/wso2/carbon/identity/provisioning/connector/scim2/SCIM2ProvisioningConnector.java
@@ -88,6 +88,10 @@ public class SCIM2ProvisioningConnector extends AbstractOutboundProvisioningConn
             String accessToken = null;
             String apiKeyHeader = null;
             String apiKeyValue = null;
+            String oauthTokenEndpoint = null;
+            String oauthClientId = null;
+            String oauthClientSecret = null;
+            String oauthScope = null;
 
             for (Property property : provisioningProperties) {
                 if (SCIM2ProvisioningConnectorConstants.SCIM2_USER_EP.equals(property.getName())) {
@@ -107,6 +111,14 @@ public class SCIM2ProvisioningConnector extends AbstractOutboundProvisioningConn
                     apiKeyHeader = property.getValue() != null ? property.getValue() : property.getDefaultValue();
                 } else if (SCIM2ProvisioningConnectorConstants.SCIM2_API_KEY_VALUE.equals(property.getName())) {
                     apiKeyValue = property.getValue() != null ? property.getValue() : property.getDefaultValue();
+                } else if (SCIM2ProvisioningConnectorConstants.SCIM2_OAUTH_TOKEN_ENDPOINT.equals(property.getName())) {
+                    oauthTokenEndpoint = property.getValue() != null ? property.getValue() : property.getDefaultValue();
+                } else if (SCIM2ProvisioningConnectorConstants.SCIM2_OAUTH_CLIENT_ID.equals(property.getName())) {
+                    oauthClientId = property.getValue() != null ? property.getValue() : property.getDefaultValue();
+                } else if (SCIM2ProvisioningConnectorConstants.SCIM2_OAUTH_CLIENT_SECRET.equals(property.getName())) {
+                    oauthClientSecret = property.getValue() != null ? property.getValue() : property.getDefaultValue();
+                } else if (SCIM2ProvisioningConnectorConstants.SCIM2_OAUTH_SCOPE.equals(property.getName())) {
+                    oauthScope = property.getValue() != null ? property.getValue() : property.getDefaultValue();
                 } else if (SCIM2ProvisioningConnectorConstants.SCIM2_USERSTORE_DOMAIN.equals(property.getName())) {
                     userStoreDomainName = property.getValue() != null ? property.getValue()
                             : property.getDefaultValue();
@@ -125,21 +137,28 @@ public class SCIM2ProvisioningConnector extends AbstractOutboundProvisioningConn
             }
 
             // Configure authentication based on type.
-            configureAuthentication(username, password, accessToken, apiKeyHeader, apiKeyValue);
+            configureAuthentication(username, password, accessToken, apiKeyHeader, apiKeyValue,
+                    oauthTokenEndpoint, oauthClientId, oauthClientSecret, oauthScope);
         }
     }
 
     /**
      * Configure authentication on the SCIM provider based on authentication type.
      *
-     * @param username       Username for BASIC auth.
-     * @param password       Password for BASIC auth.
-     * @param accessToken    Access token for BEARER auth.
-     * @param apiKeyHeader   API key header name for API_KEY auth.
-     * @param apiKeyValue    API key value for API_KEY auth.
+     * @param username            Username for BASIC auth.
+     * @param password            Password for BASIC auth.
+     * @param accessToken         Access token for BEARER auth.
+     * @param apiKeyHeader        API key header name for API_KEY auth.
+     * @param apiKeyValue         API key value for API_KEY auth.
+     * @param oauthTokenEndpoint  OAuth token endpoint for CLIENT_CREDENTIALS auth.
+     * @param oauthClientId       OAuth client ID for CLIENT_CREDENTIALS auth.
+     * @param oauthClientSecret   OAuth client secret for CLIENT_CREDENTIALS auth.
+     * @param oauthScope          OAuth scope for CLIENT_CREDENTIALS auth.
      */
     private void configureAuthentication(String username, String password, String accessToken,
-                                        String apiKeyHeader, String apiKeyValue) {
+                                        String apiKeyHeader, String apiKeyValue,
+                                        String oauthTokenEndpoint, String oauthClientId,
+                                        String oauthClientSecret, String oauthScope) {
 
         // Parse authentication type from string value, default to BASIC if not specified.
         AuthenticationType authType = StringUtils.isBlank(authenticationType) ?
@@ -173,6 +192,21 @@ public class SCIM2ProvisioningConnector extends AbstractOutboundProvisioningConn
                 } else {
                     log.warn("API_KEY authentication requires both header name and value. " +
                             "Skipping authentication configuration.");
+                }
+                break;
+            case CLIENT_CREDENTIALS:
+                if (StringUtils.isNotBlank(oauthTokenEndpoint) && StringUtils.isNotBlank(oauthClientId)
+                        && StringUtils.isNotBlank(oauthClientSecret)) {
+                    SCIM2OAuth2TokenManager tokenManager = new SCIM2OAuth2TokenManager(
+                            oauthTokenEndpoint, oauthClientId, oauthClientSecret, oauthScope);
+                    scimProvider.setTokenManager(tokenManager);
+                    scimProvider.setProperty(SCIM2CommonConstants.AUTHENTICATION_TYPE, authType.getValue());
+                    if (log.isDebugEnabled()) {
+                        log.debug("Configured CLIENT_CREDENTIALS authentication for SCIM2 provisioning");
+                    }
+                } else {
+                    log.warn("CLIENT_CREDENTIALS authentication requires token endpoint, client ID, " +
+                            "and client secret. Skipping authentication configuration.");
                 }
                 break;
             case NONE:

--- a/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/main/java/org/wso2/carbon/identity/provisioning/connector/scim2/SCIM2ProvisioningConnectorConstants.java
+++ b/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/main/java/org/wso2/carbon/identity/provisioning/connector/scim2/SCIM2ProvisioningConnectorConstants.java
@@ -41,6 +41,12 @@ public class SCIM2ProvisioningConnectorConstants {
     public static final String SCIM2_API_KEY_HEADER = "scim2-api-key-header";
     public static final String SCIM2_API_KEY_VALUE = "scim2-api-key-value";
 
+    // OAuth 2.0 Client Credentials authentication constants.
+    public static final String SCIM2_OAUTH_TOKEN_ENDPOINT = "scim2-oauth-token-endpoint";
+    public static final String SCIM2_OAUTH_CLIENT_ID = "scim2-oauth-client-id";
+    public static final String SCIM2_OAUTH_CLIENT_SECRET = "scim2-oauth-client-secret";
+    public static final String SCIM2_OAUTH_SCOPE = "scim2-oauth-scope";
+
     public static final String DEFAULT_SCIM2_CORE_DIALECT = "urn:ietf:params:scim:schemas:core:2.0";
     public static final String DEFAULT_SCIM2_USER_DIALECT = "urn:ietf:params:scim:schemas:core:2.0:User";
     public static final String DEFAULT_SCIM2_ENTERPRISE_DIALECT

--- a/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/main/java/org/wso2/carbon/identity/provisioning/connector/scim2/SCIM2ProvisioningConnectorFactory.java
+++ b/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/main/java/org/wso2/carbon/identity/provisioning/connector/scim2/SCIM2ProvisioningConnectorFactory.java
@@ -96,7 +96,8 @@ public class SCIM2ProvisioningConnectorFactory extends AbstractProvisioningConne
         authMode.setOptions(new String[]{
                 AuthenticationType.BASIC.getValue(),
                 AuthenticationType.BEARER.getValue(),
-                AuthenticationType.API_KEY.getValue()
+                AuthenticationType.API_KEY.getValue(),
+                AuthenticationType.CLIENT_CREDENTIALS.getValue()
         });
         authMode.setDefaultValue(AuthenticationType.BASIC.getValue());
 
@@ -142,24 +143,55 @@ public class SCIM2ProvisioningConnectorFactory extends AbstractProvisioningConne
         apiKeyValue.setType("string");
         apiKeyValue.setConfidential(true);
 
+        Property oauthTokenEndpoint = new Property();
+        oauthTokenEndpoint.setName(SCIM2ProvisioningConnectorConstants.SCIM2_OAUTH_TOKEN_ENDPOINT);
+        oauthTokenEndpoint.setDisplayName("OAuth Token Endpoint URL");
+        oauthTokenEndpoint.setDisplayOrder(7);
+        oauthTokenEndpoint.setRequired(false);
+        oauthTokenEndpoint.setType("string");
+
+        Property oauthClientId = new Property();
+        oauthClientId.setName(SCIM2ProvisioningConnectorConstants.SCIM2_OAUTH_CLIENT_ID);
+        oauthClientId.setDisplayName("OAuth Client ID");
+        oauthClientId.setDisplayOrder(8);
+        oauthClientId.setRequired(false);
+        oauthClientId.setType("string");
+        oauthClientId.setConfidential(true);
+
+        Property oauthClientSecret = new Property();
+        oauthClientSecret.setName(SCIM2ProvisioningConnectorConstants.SCIM2_OAUTH_CLIENT_SECRET);
+        oauthClientSecret.setDisplayName("OAuth Client Secret");
+        oauthClientSecret.setDisplayOrder(9);
+        oauthClientSecret.setRequired(false);
+        oauthClientSecret.setType("string");
+        oauthClientSecret.setConfidential(true);
+
+        Property oauthScope = new Property();
+        oauthScope.setName(SCIM2ProvisioningConnectorConstants.SCIM2_OAUTH_SCOPE);
+        oauthScope.setDisplayName("OAuth Scope");
+        oauthScope.setDescription("Optional, space-separated list of scopes");
+        oauthScope.setDisplayOrder(10);
+        oauthScope.setRequired(false);
+        oauthScope.setType("string");
+
         Property userEndpoint = new Property();
         userEndpoint.setName(SCIM2ProvisioningConnectorConstants.SCIM2_USER_EP);
         userEndpoint.setDisplayName("User Endpoint");
-        userEndpoint.setDisplayOrder(7);
+        userEndpoint.setDisplayOrder(11);
         userEndpoint.setRequired(true);
         userEndpoint.setType("string");
 
         Property groupEndpoint = new Property();
         groupEndpoint.setName(SCIM2ProvisioningConnectorConstants.SCIM2_GROUP_EP);
         groupEndpoint.setDisplayName("Group Endpoint");
-        groupEndpoint.setDisplayOrder(8);
+        groupEndpoint.setDisplayOrder(12);
         groupEndpoint.setType("string");
         groupEndpoint.setRequired(false);
 
         Property userStoreDomain = new Property();
         userStoreDomain.setName(SCIM2ProvisioningConnectorConstants.SCIM2_USERSTORE_DOMAIN);
         userStoreDomain.setDisplayName("User Store Domain");
-        userStoreDomain.setDisplayOrder(9);
+        userStoreDomain.setDisplayOrder(13);
         userStoreDomain.setRequired(false);
         userStoreDomain.setType("string");
 
@@ -167,7 +199,7 @@ public class SCIM2ProvisioningConnectorFactory extends AbstractProvisioningConne
         passwordProvisioning.setName(SCIM2ProvisioningConnectorConstants.SCIM2_ENABLE_PASSWORD_PROVISIONING);
         passwordProvisioning.setDisplayName("Enable Password Provisioning");
         passwordProvisioning.setDescription("Enable User password provisioning to a SCIM2 domain");
-        passwordProvisioning.setDisplayOrder(10);
+        passwordProvisioning.setDisplayOrder(14);
         passwordProvisioning.setRequired(false);
         passwordProvisioning.setType("boolean");
         passwordProvisioning.setDefaultValue("true");
@@ -175,7 +207,7 @@ public class SCIM2ProvisioningConnectorFactory extends AbstractProvisioningConne
         SubProperty defaultPassword = new SubProperty();
         defaultPassword.setName(SCIM2ProvisioningConnectorConstants.SCIM2_DEFAULT_PASSWORD);
         defaultPassword.setDisplayName("Default Password");
-        defaultPassword.setDisplayOrder(11);
+        defaultPassword.setDisplayOrder(15);
         defaultPassword.setRequired(false);
         defaultPassword.setType("string");
         defaultPassword.setConfidential(true);
@@ -187,6 +219,10 @@ public class SCIM2ProvisioningConnectorFactory extends AbstractProvisioningConne
         properties.add(accessToken);
         properties.add(apiKeyHeader);
         properties.add(apiKeyValue);
+        properties.add(oauthTokenEndpoint);
+        properties.add(oauthClientId);
+        properties.add(oauthClientSecret);
+        properties.add(oauthScope);
         properties.add(userEndpoint);
         properties.add(groupEndpoint);
         properties.add(userStoreDomain);

--- a/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/test/java/org.wso2.carbon.identity.provisioning.connector.scim2.test/SCIM2ProvisioningConnectorFactoryTest.java
+++ b/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/test/java/org.wso2.carbon.identity.provisioning.connector.scim2.test/SCIM2ProvisioningConnectorFactoryTest.java
@@ -55,7 +55,7 @@ public class SCIM2ProvisioningConnectorFactoryTest {
 
         // Verify properties are returned.
         Assert.assertNotNull(properties);
-        Assert.assertEquals(properties.size(), 10, "Should have 10 configuration properties");
+        Assert.assertEquals(properties.size(), 14, "Should have 14 configuration properties");
     }
 
     @Test

--- a/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/test/java/org/wso2/carbon/identity/provisioning/connector/scim2/SCIM2OAuth2TokenManagerTest.java
+++ b/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/test/java/org/wso2/carbon/identity/provisioning/connector/scim2/SCIM2OAuth2TokenManagerTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.provisioning.connector.scim2;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.fail;
+
+/**
+ * Tests for SCIM2OAuth2TokenManager.
+ */
+public class SCIM2OAuth2TokenManagerTest {
+
+    @Test(expectedExceptions = IllegalArgumentException.class,
+            expectedExceptionsMessageRegExp = "Token endpoint URL must not be empty")
+    public void testConstructorWithEmptyTokenEndpoint() {
+
+        new SCIM2OAuth2TokenManager("", "clientId", "clientSecret", null);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class,
+            expectedExceptionsMessageRegExp = "Token endpoint URL must not be empty")
+    public void testConstructorWithNullTokenEndpoint() {
+
+        new SCIM2OAuth2TokenManager(null, "clientId", "clientSecret", null);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class,
+            expectedExceptionsMessageRegExp = "Token endpoint must use HTTPS.*")
+    public void testConstructorWithHttpEndpoint() {
+
+        new SCIM2OAuth2TokenManager("http://token.example.com/token", "clientId", "clientSecret", null);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class,
+            expectedExceptionsMessageRegExp = "Client ID must not be empty")
+    public void testConstructorWithEmptyClientId() {
+
+        new SCIM2OAuth2TokenManager("https://token.example.com/token", "", "clientSecret", null);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class,
+            expectedExceptionsMessageRegExp = "Client secret must not be empty")
+    public void testConstructorWithEmptyClientSecret() {
+
+        new SCIM2OAuth2TokenManager("https://token.example.com/token", "clientId", "", null);
+    }
+
+    @Test
+    public void testConstructorWithValidParameters() {
+
+        SCIM2OAuth2TokenManager tokenManager = new SCIM2OAuth2TokenManager(
+                "https://token.example.com/token", "clientId", "clientSecret", "openid");
+        assertNotNull(tokenManager);
+    }
+
+    @Test
+    public void testConstructorWithNullScope() {
+
+        SCIM2OAuth2TokenManager tokenManager = new SCIM2OAuth2TokenManager(
+                "https://token.example.com/token", "clientId", "clientSecret", null);
+        assertNotNull(tokenManager);
+    }
+
+    @Test
+    public void testHttpsValidationIsCaseInsensitive() {
+
+        SCIM2OAuth2TokenManager tokenManager = new SCIM2OAuth2TokenManager(
+                "HTTPS://token.example.com/token", "clientId", "clientSecret", null);
+        assertNotNull(tokenManager);
+    }
+
+    @Test
+    public void testGetAccessTokenFailsWithUnreachableEndpoint() {
+
+        SCIM2OAuth2TokenManager tokenManager = new SCIM2OAuth2TokenManager(
+                "https://localhost:19999/nonexistent/token", "clientId", "clientSecret", null);
+        try {
+            tokenManager.getAccessToken();
+            fail("Expected exception when token endpoint is unreachable");
+        } catch (Exception e) {
+            assertNotNull(e);
+        }
+    }
+
+    @Test
+    public void testRefreshTokenFailsWithUnreachableEndpoint() {
+
+        SCIM2OAuth2TokenManager tokenManager = new SCIM2OAuth2TokenManager(
+                "https://localhost:19999/nonexistent/token", "clientId", "clientSecret", null);
+        try {
+            tokenManager.refreshToken(null);
+            fail("Expected exception when token endpoint is unreachable");
+        } catch (Exception e) {
+            assertNotNull(e);
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/test/resources/testng.xml
@@ -7,6 +7,7 @@
             <class name="org.wso2.carbon.identity.provisioning.connector.scim2.test.SCIM2ProvisioningConnectorTest"/>
             <class name="org.wso2.carbon.identity.provisioning.connector.scim2.test.SCIMClaimResolverTest"/>
             <class name="org.wso2.carbon.identity.provisioning.connector.scim2.test.SCIM2ConnectorUtilTest"/>
+            <class name="org.wso2.carbon.identity.provisioning.connector.scim2.SCIM2OAuth2TokenManagerTest"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
## Purpose
This pull request introduces support for OAuth 2.0 Client Credentials authentication to the SCIM2 provisioning connector. It adds a new authentication mode, updates configuration properties to support the necessary OAuth parameters, and implements a dedicated token manager for handling OAuth 2.0 token acquisition. The main changes are grouped below:

**OAuth 2.0 Client Credentials Authentication Support**

* Added a new `CLIENT_CREDENTIALS` authentication type to the connector, allowing SCIM2 outbound provisioning using OAuth 2.0 Client Credentials flow.
* Implemented the `SCIM2OAuth2TokenManager` class to handle token acquisition and refresh using the client credentials grant, including secure handling and error reporting.
* Updated the authentication configuration logic in `SCIM2ProvisioningConnector` to support and initialize the new OAuth 2.0 authentication mode based on new configuration properties. [[1]](diffhunk://#diff-f6635fac98f39272a692a2d2f45996db89d1e273e8345c6a481b5d422d32804bR91-R94) [[2]](diffhunk://#diff-f6635fac98f39272a692a2d2f45996db89d1e273e8345c6a481b5d422d32804bR114-R121) [[3]](diffhunk://#diff-f6635fac98f39272a692a2d2f45996db89d1e273e8345c6a481b5d422d32804bL128-R141) [[4]](diffhunk://#diff-f6635fac98f39272a692a2d2f45996db89d1e273e8345c6a481b5d422d32804bR153-R161) [[5]](diffhunk://#diff-f6635fac98f39272a692a2d2f45996db89d1e273e8345c6a481b5d422d32804bR197-R211)

**Configuration Enhancements**

* Added new configuration properties for OAuth 2.0 (token endpoint, client ID, client secret, and scope) in both the constants and the connector factory, and adjusted display order to accommodate these new fields. [[1]](diffhunk://#diff-ab8f42bf1fb86245867ae1c69390509890572bc9cd55c5a26d5c0bfb94607d2aR44-R49) [[2]](diffhunk://#diff-4b1b814be8b366bc1bd0b1008147a7c4f4601d4c5512d25d1af1a12986ac0f89R146-R210) [[3]](diffhunk://#diff-4b1b814be8b366bc1bd0b1008147a7c4f4601d4c5512d25d1af1a12986ac0f89R222-R225)

**Testing Updates**

* Updated the connector factory test to expect the new total number of configuration properties, reflecting the addition of OAuth-related fields.

### Related Issues
- https://github.com/wso2/product-is/issues/26544
- https://github.com/wso2/product-is/issues/26639

### Related PRs
- https://github.com/wso2-extensions/identity-client-scim2/pull/43