### PR TITLE
Use sub-attribute paths in SCIM2 PATCH replace to prevent data loss on complex attributes

### DIFF
--- a/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/main/java/org/wso2/carbon/identity/provisioning/connector/scim2/util/SCIM2ConnectorUtil.java
+++ b/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/main/java/org/wso2/carbon/identity/provisioning/connector/scim2/util/SCIM2ConnectorUtil.java
@@ -116,8 +116,14 @@ public class SCIM2ConnectorUtil {
                     // For extension schemas, create patch operations for each sub-attribute.
                     buildExtensionSchemaPatchOperations((ComplexAttribute) attribute, attributeName,
                             patchOperations, encoder);
+                } else if (attribute instanceof ComplexAttribute && !Boolean.TRUE.equals(attribute.getMultiValued())) {
+                    // For non-multi-valued complex attributes (e.g., name), create sub-attribute level
+                    // patch operations (e.g., name.familyName, name.givenName) to avoid replacing the
+                    // entire complex attribute and losing sibling sub-attributes.
+                    buildSubAttributePatchOperations((ComplexAttribute) attribute, attributeName,
+                            patchOperations, encoder);
                 } else {
-                    // For core attributes, create a single patch operation.
+                    // For simple attributes and multi-valued attributes, create a single patch operation.
                     Object attributeValue = getAttributeValue(attribute, encoder);
                     if (attributeValue != null) {
                         createAndAddPatchOperation(attributeName, attributeValue, patchOperations);
@@ -200,14 +206,48 @@ public class SCIM2ConnectorUtil {
                 // Build the full path: schema:attributeName.
                 String fullPath = schemaUri + ":" + subAttrName;
 
-                // Extract attribute value and create patch operation.
-                Object value = getAttributeValue(subAttribute, encoder);
-                if (value != null) {
-                    createAndAddPatchOperation(fullPath, value, patchOperations);
+                if (subAttribute instanceof ComplexAttribute && !Boolean.TRUE.equals(subAttribute.getMultiValued())) {
+                    // For non-multi-valued complex sub-attributes (e.g., manager), create sub-sub-attribute
+                    // level patch operations (e.g., urn:...:User:manager.displayName) to avoid replacing
+                    // the entire complex sub-attribute and losing sibling sub-attributes.
+                    buildSubAttributePatchOperations((ComplexAttribute) subAttribute, fullPath,
+                            patchOperations, encoder);
+                } else {
+                    // For simple and multi-valued sub-attributes, create a single patch operation.
+                    Object value = getAttributeValue(subAttribute, encoder);
+                    if (value != null) {
+                        createAndAddPatchOperation(fullPath, value, patchOperations);
+                    }
                 }
             }
         } catch (Exception e) {
             log.error("Error building extension schema patch operations for schema: " + schemaUri, e);
+        }
+    }
+
+    /**
+     * Builds PATCH operations for each sub-attribute of a non-multi-valued complex attribute using
+     * dotted paths (e.g., name.familyName, urn:...:User:manager.displayName). This avoids replacing
+     * the entire complex attribute and losing sibling sub-attributes that are not included in the update.
+     *
+     * @param complexAttribute The complex attribute whose sub-attributes should be patched individually.
+     * @param parentPath       The parent path prefix (e.g., "name" or "urn:...:User:manager").
+     * @param patchOperations  List to add patch operations to.
+     * @param encoder          JSONEncoder for encoding attribute values.
+     */
+    private static void buildSubAttributePatchOperations(ComplexAttribute complexAttribute, String parentPath,
+                                                          List<PatchOperation> patchOperations, JSONEncoder encoder) {
+
+        Map<String, Attribute> subAttrs = complexAttribute.getSubAttributesList();
+        if (subAttrs == null || subAttrs.isEmpty()) {
+            return;
+        }
+        for (Map.Entry<String, Attribute> sub : subAttrs.entrySet()) {
+            String subPath = parentPath + "." + sub.getKey();
+            Object subValue = getAttributeValue(sub.getValue(), encoder);
+            if (subValue != null) {
+                createAndAddPatchOperation(subPath, subValue, patchOperations);
+            }
         }
     }
 

--- a/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/test/java/org.wso2.carbon.identity.provisioning.connector.scim2.test/SCIM2ConnectorUtilTest.java
+++ b/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/test/java/org.wso2.carbon.identity.provisioning.connector.scim2.test/SCIM2ConnectorUtilTest.java
@@ -32,6 +32,7 @@ import org.wso2.carbon.identity.scim2.common.impl.IdentitySCIMManager;
 import org.wso2.carbon.identity.scim2.common.utils.AttributeMapper;
 import org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtils;
 import org.wso2.charon3.core.attributes.Attribute;
+import org.wso2.charon3.core.attributes.ComplexAttribute;
 import org.wso2.charon3.core.attributes.SimpleAttribute;
 import org.wso2.charon3.core.exceptions.CharonException;
 import org.wso2.charon3.core.extensions.UserManager;
@@ -180,6 +181,145 @@ public class SCIM2ConnectorUtilTest {
         // Verify empty list is returned.
         assertNotNull(patchOperations, "Patch operations should not be null");
         assertTrue(patchOperations.isEmpty(), "Patch operations should be empty for user with empty attributes");
+    }
+
+    @Test
+    public void testBuildPatchOperationsFromUserWithComplexAttribute() throws CharonException {
+
+        // Create a User with a non-multi-valued complex attribute (e.g., name).
+        User user = Mockito.mock(User.class);
+        Map<String, Attribute> attributeList = new HashMap<>();
+
+        // Create a complex "name" attribute with sub-attributes familyName and givenName.
+        ComplexAttribute nameAttr = Mockito.mock(ComplexAttribute.class);
+        Mockito.when(nameAttr.getName()).thenReturn(SCIMConstants.UserSchemaConstants.NAME);
+        Mockito.when(nameAttr.getMultiValued()).thenReturn(false);
+
+        Map<String, Attribute> subAttributes = new HashMap<>();
+
+        SimpleAttribute familyNameAttr = Mockito.mock(SimpleAttribute.class);
+        Mockito.when(familyNameAttr.getName()).thenReturn(SCIMConstants.UserSchemaConstants.FAMILY_NAME);
+        Mockito.when(familyNameAttr.getValue()).thenReturn("Smith");
+        subAttributes.put(SCIMConstants.UserSchemaConstants.FAMILY_NAME, familyNameAttr);
+
+        SimpleAttribute givenNameAttr = Mockito.mock(SimpleAttribute.class);
+        Mockito.when(givenNameAttr.getName()).thenReturn(SCIMConstants.UserSchemaConstants.GIVEN_NAME);
+        Mockito.when(givenNameAttr.getValue()).thenReturn("John");
+        subAttributes.put(SCIMConstants.UserSchemaConstants.GIVEN_NAME, givenNameAttr);
+
+        Mockito.when(nameAttr.getSubAttributesList()).thenReturn(subAttributes);
+        attributeList.put(SCIMConstants.UserSchemaConstants.NAME, nameAttr);
+
+        Mockito.when(user.getAttributeList()).thenReturn(attributeList);
+
+        // Build patch operations.
+        List<PatchOperation> patchOperations = SCIM2ConnectorUtil.buildPatchOperationsFromUser(user);
+
+        // Verify sub-attribute level patch operations are created.
+        assertNotNull(patchOperations, "Patch operations should not be null");
+        assertEquals(patchOperations.size(), 2, "Should have 2 patch operations for name sub-attributes");
+
+        // Verify each operation uses dotted sub-attribute paths.
+        Map<String, Object> pathValueMap = new HashMap<>();
+        for (PatchOperation op : patchOperations) {
+            assertEquals(op.getOperation(), SCIMConstants.OperationalConstants.REPLACE,
+                    "Operation should be REPLACE");
+            pathValueMap.put(op.getPath(), op.getValues());
+        }
+
+        assertTrue(pathValueMap.containsKey("name.familyName"),
+                "Should have patch operation for name.familyName");
+        assertEquals(pathValueMap.get("name.familyName"), "Smith",
+                "name.familyName value should be Smith");
+
+        assertTrue(pathValueMap.containsKey("name.givenName"),
+                "Should have patch operation for name.givenName");
+        assertEquals(pathValueMap.get("name.givenName"), "John",
+                "name.givenName value should be John");
+    }
+
+    @Test
+    public void testBuildPatchOperationsFromUserWithExtensionComplexSubAttribute() throws CharonException {
+
+        // Create a User with an extension schema attribute containing a complex sub-attribute (e.g., manager).
+        User user = Mockito.mock(User.class);
+        Map<String, Attribute> attributeList = new HashMap<>();
+
+        String enterpriseSchemaUri = SCIM2ProvisioningConnectorConstants.DEFAULT_SCIM2_ENTERPRISE_DIALECT;
+        scimCommonUtilsMock.when(SCIMCommonUtils::getCustomSchemaURI).thenReturn(null);
+
+        // Create the extension schema top-level complex attribute.
+        ComplexAttribute extensionAttr = Mockito.mock(ComplexAttribute.class);
+        Mockito.when(extensionAttr.getName()).thenReturn(enterpriseSchemaUri);
+        Mockito.when(extensionAttr.getMultiValued()).thenReturn(false);
+
+        Map<String, Attribute> extensionSubAttributes = new HashMap<>();
+
+        // Add a simple sub-attribute (department).
+        SimpleAttribute departmentAttr = Mockito.mock(SimpleAttribute.class);
+        Mockito.when(departmentAttr.getName()).thenReturn("department");
+        Mockito.when(departmentAttr.getValue()).thenReturn("Engineering");
+        Mockito.when(departmentAttr.getMultiValued()).thenReturn(false);
+        extensionSubAttributes.put("department", departmentAttr);
+
+        // Add a complex non-multi-valued sub-attribute (manager) with sub-sub-attributes.
+        ComplexAttribute managerAttr = Mockito.mock(ComplexAttribute.class);
+        Mockito.when(managerAttr.getName()).thenReturn("manager");
+        Mockito.when(managerAttr.getMultiValued()).thenReturn(false);
+
+        Map<String, Attribute> managerSubAttributes = new HashMap<>();
+        SimpleAttribute managerDisplayName = Mockito.mock(SimpleAttribute.class);
+        Mockito.when(managerDisplayName.getName()).thenReturn("displayName");
+        Mockito.when(managerDisplayName.getValue()).thenReturn("Jane Manager");
+        managerSubAttributes.put("displayName", managerDisplayName);
+
+        SimpleAttribute managerValue = Mockito.mock(SimpleAttribute.class);
+        Mockito.when(managerValue.getName()).thenReturn("value");
+        Mockito.when(managerValue.getValue()).thenReturn("user123");
+        managerSubAttributes.put("value", managerValue);
+
+        Mockito.when(managerAttr.getSubAttributesList()).thenReturn(managerSubAttributes);
+        extensionSubAttributes.put("manager", managerAttr);
+
+        Mockito.when(extensionAttr.getSubAttributesList()).thenReturn(extensionSubAttributes);
+        attributeList.put(enterpriseSchemaUri, extensionAttr);
+
+        Mockito.when(user.getAttributeList()).thenReturn(attributeList);
+
+        // Build patch operations.
+        List<PatchOperation> patchOperations = SCIM2ConnectorUtil.buildPatchOperationsFromUser(user);
+
+        // Verify patch operations.
+        assertNotNull(patchOperations, "Patch operations should not be null");
+        assertEquals(patchOperations.size(), 3,
+                "Should have 3 patch operations: department + manager.displayName + manager.value");
+
+        Map<String, Object> pathValueMap = new HashMap<>();
+        for (PatchOperation op : patchOperations) {
+            assertEquals(op.getOperation(), SCIMConstants.OperationalConstants.REPLACE,
+                    "Operation should be REPLACE");
+            pathValueMap.put(op.getPath(), op.getValues());
+        }
+
+        // Verify simple extension sub-attribute.
+        String departmentPath = enterpriseSchemaUri + ":department";
+        assertTrue(pathValueMap.containsKey(departmentPath),
+                "Should have patch operation for department");
+        assertEquals(pathValueMap.get(departmentPath), "Engineering",
+                "department value should be Engineering");
+
+        // Verify complex extension sub-attribute is split into sub-sub-attribute paths.
+        String managerDisplayNamePath = enterpriseSchemaUri + ":manager.displayName";
+        assertTrue(pathValueMap.containsKey(managerDisplayNamePath),
+                "Should have patch operation for manager.displayName");
+        assertEquals(pathValueMap.get(managerDisplayNamePath), "Jane Manager",
+                "manager.displayName value should be Jane Manager");
+
+        String managerValuePath = enterpriseSchemaUri + ":manager.value";
+        assertTrue(pathValueMap.containsKey(managerValuePath),
+                "Should have patch operation for manager.value");
+        assertEquals(pathValueMap.get(managerValuePath), "user123",
+                "manager.value value should be user123");
     }
 
     @Test

--- a/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/test/java/org.wso2.carbon.identity.provisioning.connector.scim2.test/SCIM2ProvisioningConnectorTest.java
+++ b/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/test/java/org.wso2.carbon.identity.provisioning.connector.scim2.test/SCIM2ProvisioningConnectorTest.java
@@ -400,11 +400,11 @@ public class SCIM2ProvisioningConnectorTest {
         assertTrue(patchOps.stream().anyMatch(op -> "nickName".equals(op.getPath()) &&
                 "JD".equals(op.getValues())), "Should have nickName");
 
-        // Verify core complex attribute.
-        Optional<PatchOperation> nameOp = patchOps.stream()
-                .filter(op -> "name".equals(op.getPath())).findFirst();
-        assertTrue(nameOp.isPresent(), "Should have name operation");
-        assertNotNull(nameOp.get().getValues(), "Name value should not be null");
+        // Verify core complex attribute is split into sub-attribute level operations.
+        assertTrue(patchOps.stream().anyMatch(op -> "name.familyName".equals(op.getPath()) &&
+                "Doe".equals(op.getValues())), "Should have name.familyName operation");
+        assertTrue(patchOps.stream().anyMatch(op -> "name.givenName".equals(op.getPath()) &&
+                "John".equals(op.getValues())), "Should have name.givenName operation");
 
         // Verify core multi-valued attribute.
         Optional<PatchOperation> emailsOp = patchOps.stream()
@@ -420,17 +420,13 @@ public class SCIM2ProvisioningConnectorTest {
                 "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:employeeNumber".equals(op.getPath()) &&
                 "EMP001".equals(op.getValues())), "Should have employeeNumber with full path");
 
-        // Verify extension complex attribute.
-        Optional<PatchOperation> managerOp = patchOps.stream()
-                .filter(op -> "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:manager".equals(op.getPath()))
-                .findFirst();
-        assertTrue(managerOp.isPresent(), "Should have manager operation");
-        Object managerValue = managerOp.get().getValues();
-        assertNotNull(managerValue, "Manager value should not be null");
-        assertTrue(managerValue instanceof JSONObject, "Manager should be JSONObject");
-        JSONObject managerJson = (JSONObject) managerValue;
-        assertEquals(managerJson.getString("value"), "manager-id-123");
-        assertEquals(managerJson.getString("displayName"), "Manager Name");
+        // Verify extension complex attribute is split into sub-sub-attribute level operations.
+        assertTrue(patchOps.stream().anyMatch(op ->
+                "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:manager.value".equals(op.getPath()) &&
+                "manager-id-123".equals(op.getValues())), "Should have manager.value operation");
+        assertTrue(patchOps.stream().anyMatch(op ->
+                "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:manager.displayName".equals(op.getPath()) &&
+                "Manager Name".equals(op.getValues())), "Should have manager.displayName operation");
 
         // Verify all operations are REPLACE with proper structure.
         for (PatchOperation op : patchOps) {


### PR DESCRIPTION
Here is a **refined version** of your description with the **inbound `givenName` / `familyName` inconsistency added**, while keeping it concise and technical.

---

## Problem

When outbound provisioning updated a user via SCIM2 PATCH, partial updates to complex attributes caused sibling sub-attributes to be silently wiped on the target server.

### What the old code sent

```json
{ "op": "replace", "path": "name", "value": { "familyName": "Smith" } }
```

## Fix

For non-multi-valued `ComplexAttributes`, iterate sub-attributes and emit individual PATCH operations with dotted paths instead of a single operation for the whole object:

```json
{ "op": "replace", "path": "name.familyName", "value": "Smith" }
{ "op": "replace", "path": "name.givenName",  "value": "John"  }
```

Charon's level-two and level-three handlers update only the targeted sub-attribute, leaving siblings untouched. This applies to both core complex attributes (`name`) and extension complex sub-attributes (e.g., `manager`).

Multi-valued complex attributes (`emails`, `phoneNumbers`, etc.) continue to use full array replacement, which is the correct SCIM behaviour.

The null-unsafe unboxing was replaced with `!Boolean.TRUE.equals(getMultiValued())`, and the shared sub-attribute iteration was extracted into a helper method `buildSubAttributePatchOperations`.
