### PR TITLE
Fix wso2 system schema claims not getting outbound provisioned

### DIFF
--- a/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/main/java/org/wso2/carbon/identity/provisioning/connector/scim2/SCIM2ProvisioningConnector.java
+++ b/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/main/java/org/wso2/carbon/identity/provisioning/connector/scim2/SCIM2ProvisioningConnector.java
@@ -560,6 +560,7 @@ public class SCIM2ProvisioningConnector extends AbstractOutboundProvisioningConn
         return new String[]{SCIM2ProvisioningConnectorConstants.DEFAULT_SCIM2_CORE_DIALECT,
                 SCIM2ProvisioningConnectorConstants.DEFAULT_SCIM2_USER_DIALECT,
                 SCIM2ProvisioningConnectorConstants.DEFAULT_SCIM2_ENTERPRISE_DIALECT,
+                SCIM2ProvisioningConnectorConstants.SCIM_SYSTEM_USER_CLAIM_DIALECT,
                 SCIMCommonUtils.getCustomSchemaURI()};
     }
 

--- a/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/main/java/org/wso2/carbon/identity/provisioning/connector/scim2/SCIM2ProvisioningConnectorConstants.java
+++ b/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/main/java/org/wso2/carbon/identity/provisioning/connector/scim2/SCIM2ProvisioningConnectorConstants.java
@@ -45,6 +45,7 @@ public class SCIM2ProvisioningConnectorConstants {
     public static final String DEFAULT_SCIM2_USER_DIALECT = "urn:ietf:params:scim:schemas:core:2.0:User";
     public static final String DEFAULT_SCIM2_ENTERPRISE_DIALECT
             = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User";
+    public static final String SCIM_SYSTEM_USER_CLAIM_DIALECT = "urn:scim:wso2:schema";
 
     public static final String DEFAULT = "default";
     public static final String ATTRIBUTE_TYPE = ".type";

--- a/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/main/java/org/wso2/carbon/identity/provisioning/connector/scim2/util/SCIM2ConnectorUtil.java
+++ b/components/org.wso2.carbon.identity.provisioning.connector.scim2/src/main/java/org/wso2/carbon/identity/provisioning/connector/scim2/util/SCIM2ConnectorUtil.java
@@ -171,7 +171,8 @@ public class SCIM2ConnectorUtil {
         // First check against registered extension dialect URIs.
         String[] extensionDialectUris = {
                 SCIM2ProvisioningConnectorConstants.DEFAULT_SCIM2_ENTERPRISE_DIALECT,
-                SCIMCommonUtils.getCustomSchemaURI()
+                SCIMCommonUtils.getCustomSchemaURI(),
+                SCIM2ProvisioningConnectorConstants.SCIM_SYSTEM_USER_CLAIM_DIALECT
         };
 
         return Arrays.stream(extensionDialectUris)


### PR DESCRIPTION
## Purpose
This pull request enhances SCIM2 provisioning connector support by introducing a new system user claim dialect and ensuring it is recognized throughout the connector. The main changes focus on adding and integrating this new dialect constant.

**SCIM2 Dialect Support Improvements:**

* Added a new constant `SCIM_SYSTEM_USER_CLAIM_DIALECT` (`urn:scim:wso2:schema`) to `SCIM2ProvisioningConnectorConstants` to represent the system user claim dialect.
* Updated `getClaimDialectUris()` in `SCIM2ProvisioningConnector` to include the new system user claim dialect in the list of supported dialect URIs.

**Extension Schema Recognition:**

* Modified `isExtensionSchema()` in `SCIM2ConnectorUtil` to recognize the new system user claim dialect as an extension schema, ensuring it is handled correctly during schema checks.